### PR TITLE
Fixes `JsonPathDetector` path for empty objects

### DIFF
--- a/src/__tests__/path-detector.test.ts
+++ b/src/__tests__/path-detector.test.ts
@@ -47,3 +47,53 @@ test("PathDetector adds path", async () => {
 		{ ...objectEnd(), path: [] }
 	]);
 });
+
+test("PathDetector handles empty object", async () => {
+	const stream = serializeJsonValue({
+		outer: {
+			inner: {}
+		}
+	}).pipeThrough(new JsonPathDetector());
+
+	expect(await streamToArray(stream)).toEqual([
+		{ ...objectStart(), path: [] },
+		{ ...stringStart(StringRole.KEY), path: [] },
+		{ ...stringChunk("outer", StringRole.KEY), path: [] },
+		{ ...stringEnd(StringRole.KEY), path: [] },
+		{ ...colon(), path: [] },
+		{ ...objectStart(), path: ["outer"] },
+		{ ...stringStart(StringRole.KEY), path: ["outer"] },
+		{ ...stringChunk("inner", StringRole.KEY), path: ["outer"] },
+		{ ...stringEnd(StringRole.KEY), path: ["outer"] },
+		{ ...colon(), path: ["outer"] },
+		{ ...objectStart(), path: ["outer", "inner"] },
+		{ ...objectEnd(), path: ["outer", "inner"] },
+		{ ...objectEnd(), path: ["outer"] },
+		{ ...objectEnd(), path: [] }
+	]);
+});
+
+test("PathDetector handles empty array", async () => {
+	const stream = serializeJsonValue({
+		outer: {
+			inner: []
+		}
+	}).pipeThrough(new JsonPathDetector());
+
+	expect(await streamToArray(stream)).toEqual([
+		{ ...objectStart(), path: [] },
+		{ ...stringStart(StringRole.KEY), path: [] },
+		{ ...stringChunk("outer", StringRole.KEY), path: [] },
+		{ ...stringEnd(StringRole.KEY), path: [] },
+		{ ...colon(), path: [] },
+		{ ...objectStart(), path: ["outer"] },
+		{ ...stringStart(StringRole.KEY), path: ["outer"] },
+		{ ...stringChunk("inner", StringRole.KEY), path: ["outer"] },
+		{ ...stringEnd(StringRole.KEY), path: ["outer"] },
+		{ ...colon(), path: ["outer"] },
+		{ ...arrayStart(), path: ["outer", "inner"] },
+		{ ...arrayEnd(), path: ["outer", "inner"] },
+		{ ...objectEnd(), path: ["outer"] },
+		{ ...objectEnd(), path: [] }
+	]);
+});

--- a/src/json-path-detector.ts
+++ b/src/json-path-detector.ts
@@ -52,8 +52,9 @@ export class JsonPathDetector extends AbstractTransformStream<JsonChunk, JsonChu
 		} else if (chunk.type === JsonChunkType.ARRAY_START) {
 			this.stack.push({ type: "array", state: "next", key: 0 });
 		} else if (chunk.type === JsonChunkType.OBJECT_END || chunk.type === JsonChunkType.ARRAY_END) {
-			this.stack.pop();
-			this.path.pop();
+			if (this.stack.pop()?.state !== "pending") {
+				this.path.pop();
+			}
 		} else {
 			const current = this.stack[this.stack.length - 1];
 			if (current?.type === "object") {


### PR DESCRIPTION
These changes fix the `JsonPathDetector` class, which is not handling paths correctly for empty objects.

The original implementation uses a state machine that handles objects and arrays slightly differently, due to the need to recognize an object's nested property keys. To handle this, the state machine uses a special `"pending"` state when processing objects. During the `"pending"` state, no path item has been pushed for properties of the object.

When the closing brace of an empty object is encountered, the state is still `"pending"` since no properties have been seen. The original implementation of the state machine assumes that a path item for a nested property has been pushed. Since no nested property has been encountered, no additional key has been pushed and the key of the enclosing object or array is popped instead.

Consider the following JSON fragment:

```
{
  "outer": {
    "inner": { // Has path [ "outer", "inner" ]
    } // Should also have path [ "outer", "inner" ], but has path [ "outer" ]
  }
}
```

These changes fix the state machine to check the current state before conditionally popping an item from the path. The also add unit tests to check the special cases of empty objects and arrays.